### PR TITLE
[T-8760][15.0][IMP] sync_sale_picking_cost: fix the return of the outgoing sale picking

### DIFF
--- a/sync_sale_picking_cost/models/__init__.py
+++ b/sync_sale_picking_cost/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import product_template
 from . import stock_move
+from . import sale_order_line

--- a/sync_sale_picking_cost/models/sale_order_line.py
+++ b/sync_sale_picking_cost/models/sale_order_line.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Alberto Martínez <alberto.martinez@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.depends(
+        "move_ids",
+        "move_ids.stock_valuation_layer_ids",
+        "move_ids.picking_id.state",
+        "qty_delivered",
+    )
+    def _compute_purchase_price(self):
+        """
+        The purchase_price, which is the cost this module is syncing,
+        is already being computed the super() this function.
+        The function has a "is_returned" context parameter, and it
+        should be passed if the line is being returned to compute correctly
+        the purchase price.
+
+        :precondition:  A dependency of the purchase_price has been edited
+                        and it should be recomputed
+        :postcondition: The purchase_price has been computed using the
+                        'is_returned' context, and its value will be correct
+                        even when returning a move_id.
+        """
+        res = None
+        for line in self:
+            returned = not line.qty_delivered and any(
+                line.move_ids.filtered(
+                    lambda m: m.state == "done"
+                ).origin_returned_move_id
+            )
+            res = super(
+                SaleOrderLine, line.with_context(is_returned=returned)
+            )._compute_purchase_price()
+        return res

--- a/sync_sale_picking_cost/tests/__init__.py
+++ b/sync_sale_picking_cost/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_sync_sale_picking_cost

--- a/sync_sale_picking_cost/tests/test_sync_sale_picking_cost.py
+++ b/sync_sale_picking_cost/tests/test_sync_sale_picking_cost.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Alberto Martínez <alberto.martinez@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.stock_valuation_fifo_lot.tests.common import (
+    TestStockValuationFifoCommon,
+)
+
+
+class TestSyncSalePickingCost(TestStockValuationFifoCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer = cls.env["res.partner"].create({"name": "Test Customer"})
+
+    def create_sale_pick(self):
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "partner_invoice_id": self.customer.id,
+                "partner_shipping_id": self.customer.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                        },
+                    )
+                ],
+            }
+        )
+        so.action_confirm()
+
+        pick = so.picking_ids
+        pick.move_lines.write({"quantity_done": 1})
+        pick.button_validate()
+        return so, pick
+
+    def test_sale(self):
+        in_pick, in_moves = self.create_picking("in", self.lot1, ml_qty=5, price=10)
+        self.create_landed_cost(in_pick, 10)
+        sale, out_pick = self.create_sale_pick()
+        self.assertEqual(12, sale.order_line.purchase_price)
+
+    def test_return(self):
+        in_pick, in_moves = self.create_picking("in", self.lot1, ml_qty=5, price=10)
+        self.create_landed_cost(in_pick, 10)
+        sale, out_pick = self.create_sale_pick()
+        self.return_picking(out_pick, 1)
+        self.assertEqual(12, sale.order_line.purchase_price)


### PR DESCRIPTION
The _compute_average_price() of the stock_account doesn't correctly calculate the cost of the sale after the return. 

In principle, there is a case to calculate it correctly, passing it a special context, but it is not passed... This PR inherits the function to pass the context if needed